### PR TITLE
Sync business verification with localStorage

### DIFF
--- a/frontend/src/store/auth/authSlice.js
+++ b/frontend/src/store/auth/authSlice.js
@@ -304,6 +304,8 @@ const authSlice = createSlice({
         state.isSuccess=true;
         state.message=action.payload.message;
         state.user=action.payload.data;
+        // keep user data in sync with local storage
+        localStorage.setItem("user", JSON.stringify(action.payload.data));
     })
     .addCase(submitBusinessVerification.rejected, (state, action)=>{
         state.isLoading=false;
@@ -321,6 +323,8 @@ const authSlice = createSlice({
         state.isSuccess=true;
         state.message=action.payload.message;
         state.user=action.payload.data;
+        // keep user data in sync with local storage
+        localStorage.setItem("user", JSON.stringify(action.payload.data));
     })
     .addCase(updateBusinessVerification.rejected, (state, action)=>{
         state.isLoading=false;


### PR DESCRIPTION
## Summary
- keep localStorage user data in sync when submitting/updating business verification

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_687cc4efb558832b9531bd2997f6e086