### PR TITLE
Add AI report endpoints

### DIFF
--- a/backend/src/routes/ai.routes.js
+++ b/backend/src/routes/ai.routes.js
@@ -13,7 +13,7 @@ import {
   getAuctionInsights,
   getSearchSuggestions
 } from "../controllers/ai.controller.js";
-import { verifyUser } from "../middlewares/auth.middleware.js";
+import { verifyUser, verifySeller } from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
@@ -22,14 +22,14 @@ router.use(verifyUser);
 
 // AI Recommendation Routes
 router.get("/recommendations/:auctionId", getSupplierRecommendations);
-router.get("/bid-suggestions/:auctionId", getBidSuggestions);
+router.get("/bid-suggestions/:auctionId", verifySeller, getBidSuggestions);
 router.get("/user-recommendations", getUserRecommendations);
 
 // AI Prediction Routes
 router.get("/price-prediction/:auctionId", getPricePrediction);
 router.get("/demand-forecast", getDemandForecast);
 router.get("/market-trends/:categoryId", getMarketTrends);
-router.post("/win-probability", getWinProbability);
+router.post("/win-probability", verifySeller, getWinProbability);
 
 // AI Fraud Detection
 router.post("/fraud-detection", detectFraud);
@@ -42,6 +42,7 @@ router.get("/analytics", getAIAnalytics);
 
 // AI Insights
 router.get("/insights/:auctionId", getAuctionInsights);
+router.get("/auction-insights/:auctionId", getAuctionInsights);
 router.get("/search-suggestions", getSearchSuggestions);
 
 export default router; 


### PR DESCRIPTION
## Summary
- add validation and AI report route handlers for price prediction, market trends, auction insights, bid suggestions, and win probability
- secure supplier-only endpoints and expose auction insights for all users
- wire up express routes for `/api/v1/ai` including alias for `/auction-insights/:id`

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891e1f8a5ac832b95f892cc156b13c6