### PR TITLE
fix: separate AI insights for buyers and suppliers

### DIFF
--- a/frontend/src/pages/SingleAuctionDetail.jsx
+++ b/frontend/src/pages/SingleAuctionDetail.jsx
@@ -610,28 +610,44 @@ const SingleAuctionDetail = ({ noPadding }) => {
             </div>
           )}
 
-          {/* AI Auction Insights - Show to all users */}
+          {/* AI Auction Insights - Buyer only */}
           {singleAuction && (
-            <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
-              <AIAuctionInsights 
-                auctionId={params.id} 
-                categoryId={singleAuction.category?._id}
-              />
-            </div>
+            logInUser && logInUser._id === singleAuction.user?._id ? (
+              <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
+                <AIAuctionInsights
+                  auctionId={params.id}
+                  categoryId={singleAuction.category?._id}
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
+                <p className="text-gray-300">This section is not available for your role.</p>
+              </div>
+            )
           )}
 
-          {/* AI Bid Suggestions - Show only to suppliers when auction is active */}
-          {singleAuction?.status !== "over" &&
-           !auctionWinnerDetailData &&
-           auctionStarted &&
-           logInUser &&
-           logInUser._id !== singleAuction?.user?._id && (
-            <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
-              <AIBidSuggestion
-                auctionId={params.id}
-                onBidSuggestion={(suggestedAmount) => setNewBidAmount(suggestedAmount.toString())}
-              />
-            </div>
+          {/* AI Bid Assistant - Suppliers only when auction is active */}
+          {singleAuction && (
+            logInUser && logInUser._id !== singleAuction.user?._id ? (
+              auctionStatus === "active" && auctionStarted && !auctionWinnerDetailData ? (
+                <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
+                  <AIBidSuggestion
+                    auctionId={params.id}
+                    onBidSuggestion={(suggestedAmount) =>
+                      setNewBidAmount(suggestedAmount.toString())
+                    }
+                  />
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
+                  <p className="text-gray-300">This section is not available for your role.</p>
+                </div>
+              )
+            ) : (
+              <div className="flex flex-col gap-4 pt-4 border-t border-border-info-color">
+                <p className="text-gray-300">This section is not available for your role.</p>
+              </div>
+            )
           )}
 
           {/* Bidding Form - Always show for suppliers */}


### PR DESCRIPTION
## Summary
- Restrict AI Auction Insights to buyers and hide for other roles
- Show AI Bid Assistant only to suppliers when auction is active
- Add fallback messaging when sections aren't available for the user's role

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 142 problems - unused vars, etc.)
- `npm run build` (fails: top-level await and CSS syntax error)


------
https://chatgpt.com/codex/tasks/task_e_6891e70dfc54832ba464a36d35afda51