### PR TITLE
feat: refine bid statistics for completed auctions

### DIFF
--- a/frontend/src/components/BidHistory.jsx
+++ b/frontend/src/components/BidHistory.jsx
@@ -117,26 +117,42 @@ const BidHistory = () => {
   };
 
   const calculateStats = () => {
-    if (!bidData || bidData.length === 0) return { total: 0, won: 0, lost: 0, active: 0, winRate: 0, totalBidAmount: 0, avgBidAmount: 0 };
-    
-    const total = bidData.length;
-    const won = bidData.filter((bid) => isWinningBid(bid)).length;
-    const lost = bidData.filter(
+    if (!bidData || bidData.length === 0)
+      return { total: 0, won: 0, lost: 0, active: 0, winRate: 0, totalBidAmount: 0, avgBidAmount: 0 };
+
+    // Consider only completed auctions for win/loss statistics
+    const completedBids = bidData.filter(
+      (bid) => bid.auction?.status === "completed"
+    );
+
+    const total = completedBids.length;
+    const won = completedBids.filter((bid) => isWinningBid(bid)).length;
+    const lost = completedBids.filter(
+      (bid) => bid.auction?.winner && !isWinningBid(bid)
+    ).length;
+
+    const active = bidData.filter(
       (bid) =>
-        bid.auction?.status === "completed" &&
-        bid.auction?.winner &&
-        !isWinningBid(bid)
+        new Date(bid.auction?.endTime) > new Date() &&
+        bid.auction?.status !== "completed"
     ).length;
-    const active = bidData.filter(bid =>
-      new Date(bid.auction?.endTime) > new Date() &&
-      bid.auction?.status !== "completed"
-    ).length;
-    
-    const totalBidAmount = bidData.reduce((sum, bid) => sum + bid.bidAmount, 0);
+
+    const totalBidAmount = completedBids.reduce(
+      (sum, bid) => sum + bid.bidAmount,
+      0
+    );
     const avgBidAmount = total > 0 ? Math.round(totalBidAmount / total) : 0;
     const winRate = total > 0 ? Math.round((won / total) * 100) : 0;
-    
-    return { total, won, lost, active, winRate, totalBidAmount, avgBidAmount };
+
+    return {
+      total,
+      won,
+      lost,
+      active,
+      winRate,
+      totalBidAmount,
+      avgBidAmount,
+    };
   };
 
   const stats = calculateStats();

--- a/frontend/src/components/MyBids.jsx
+++ b/frontend/src/components/MyBids.jsx
@@ -78,20 +78,25 @@ const MyBids = () => {
   const calculateStats = () => {
     if (!bidData || bidData.length === 0) return { total: 0, won: 0, lost: 0, active: 0, winRate: 0 };
     
-    const total = bidData.length;
-    const won = bidData.filter((bid) => getWinnerId(bid.auction) === bid._id?.toString()).length;
-    const lost = bidData.filter(
+    const completedBids = bidData.filter(
+      (bid) => bid.auction?.status === "completed"
+    );
+
+    const total = completedBids.length;
+    const won = completedBids.filter(
+      (bid) => getWinnerId(bid.auction) === bid._id?.toString()
+    ).length;
+    const lost = completedBids.filter(
+      (bid) => bid.auction?.winner && getWinnerId(bid.auction) !== bid._id?.toString()
+    ).length;
+    const active = bidData.filter(
       (bid) =>
-        bid.auction?.status === "completed" &&
-        getWinnerId(bid.auction) !== bid._id?.toString()
+        new Date(bid.auction?.endTime) > new Date() &&
+        bid.auction?.status !== "completed"
     ).length;
-    const active = bidData.filter(bid => 
-      new Date(bid.auction?.endTime) > new Date() && 
-      bid.auction?.status !== "completed"
-    ).length;
-    
+
     const winRate = total > 0 ? Math.round((won / total) * 100) : 0;
-    
+
     return { total, won, lost, active, winRate };
   };
 


### PR DESCRIPTION
## Summary
- compute bid totals using only completed auctions in BidHistory and MyBids
- calculate wins, losses, and win rate from completed bids

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 142 problems)
- `npx eslint src/components/BidHistory.jsx src/components/MyBids.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6891f92426cc832b955a45fedf4304fb