### PR TITLE
Ensure win badges only after auction completion

### DIFF
--- a/frontend/src/components/BidHistory.jsx
+++ b/frontend/src/components/BidHistory.jsx
@@ -87,7 +87,7 @@ const BidHistory = () => {
   }, [bidData, filter, sortBy]);
 
   const getBidStatus = (bid, auction) => {
-    if (isWinningBid(bid)) {
+    if (auction.status === "completed" && isWinningBid(bid)) {
       return (
         <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs flex items-center gap-1">
           <FaTrophy /> Won
@@ -100,9 +100,17 @@ const BidHistory = () => {
         </span>
       );
     } else if (new Date(auction.endTime) < new Date()) {
-      return <span className="px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs flex items-center gap-1"><FaClock /> Expired</span>;
+      return (
+        <span className="px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs flex items-center gap-1">
+          <FaClock /> Expired
+        </span>
+      );
     } else {
-      return <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs flex items-center gap-1"><FaClock /> Active</span>;
+      return (
+        <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs flex items-center gap-1">
+          <FaClock /> Active
+        </span>
+      );
     }
   };
 

--- a/frontend/src/components/MyBids.jsx
+++ b/frontend/src/components/MyBids.jsx
@@ -38,7 +38,7 @@ const MyBids = () => {
 
   const getBidStatus = (bid, auction) => {
     const winnerId = getWinnerId(auction);
-    if (winnerId && winnerId === bid._id?.toString()) {
+    if (auction.status === "completed" && winnerId && winnerId === bid._id?.toString()) {
       return (
         <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs flex items-center gap-1">
           <FaTrophy /> Won


### PR DESCRIPTION
## Summary
- Avoid showing premature Won status in bid history
- Guard My Bids Won badge behind auction completion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 142 problems found)*
- `npm run build` *(fails: Top-level await not available)*

------
https://chatgpt.com/codex/tasks/task_e_6893416b6ccc832b983749f27834be57