### PR TITLE
Replace Win Rate card with Won Bids count

### DIFF
--- a/frontend/src/components/BidHistory.jsx
+++ b/frontend/src/components/BidHistory.jsx
@@ -187,8 +187,8 @@ const BidHistory = () => {
           <div className="bg-green-50 p-4 rounded-lg border border-green-200">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-green-600 font-medium">Win Rate</p>
-                <p className="text-2xl font-bold text-green-800">{stats.winRate}%</p>
+                <p className="text-sm text-green-600 font-medium">Won Bids</p>
+                <p className="text-2xl font-bold text-green-800">{stats.won}</p>
               </div>
               <FaTrophy className="text-green-600" size={20} />
             </div>


### PR DESCRIPTION
## Summary
- swap BidHistory's Win Rate card for a Won Bids card that shows the number of bids won

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 103 errors, 39 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68934167032c832bbe8faf06c88c898d