### PR TITLE
feat: show auction and user results separately

### DIFF
--- a/frontend/src/components/BidHistory.jsx
+++ b/frontend/src/components/BidHistory.jsx
@@ -21,7 +21,9 @@ const BidHistory = () => {
   const isWinningBid = (bid) => {
     const winner = bid.auction?.winner;
     if (!winner) return false;
-    return typeof winner === "string" ? winner === bid._id : winner._id === bid._id;
+    const winnerId =
+      typeof winner === "object" ? winner._id?.toString() : winner?.toString();
+    return bid._id?.toString() === winnerId;
   };
 
   useEffect(() => {
@@ -50,19 +52,22 @@ const BidHistory = () => {
       case "lost":
         filtered = filtered.filter(
           (bid) =>
-            bid.auction?.status === "completed" &&
+            ["completed", "over"].includes(bid.auction?.status) &&
             bid.auction?.winner &&
             !isWinningBid(bid)
         );
         break;
       case "active":
-        filtered = filtered.filter(bid =>
-          new Date(bid.auction?.endTime) > new Date() &&
-          bid.auction?.status !== "completed"
+        filtered = filtered.filter(
+          (bid) =>
+            !["completed", "over"].includes(bid.auction?.status) &&
+            new Date(bid.auction?.endTime) > new Date()
         );
         break;
       case "expired":
-        filtered = filtered.filter(bid => new Date(bid.auction?.endTime) < new Date());
+        filtered = filtered.filter((bid) =>
+          ["completed", "over"].includes(bid.auction?.status)
+        );
         break;
       default:
         break;
@@ -87,31 +92,43 @@ const BidHistory = () => {
   }, [bidData, filter, sortBy]);
 
   const getBidStatus = (bid, auction) => {
-    if (auction.status === "completed" && isWinningBid(bid)) {
-      return (
+    const isExpired = ["over", "completed"].includes(auction.status);
+    const isWinner = isWinningBid(bid);
+
+    const auctionLabel = isExpired ? (
+      <span className="px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs flex items-center gap-1">
+        <FaClock /> Expired
+      </span>
+    ) : (
+      <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs flex items-center gap-1">
+        <FaClock /> Active
+      </span>
+    );
+
+    let resultLabel = null;
+    if (isExpired && auction.winner) {
+      resultLabel = isWinner ? (
         <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs flex items-center gap-1">
-          <FaTrophy /> Won
+          <FaTrophy /> Win
         </span>
-      );
-    } else if (auction.status === "completed" && auction.winner && !isWinningBid(bid)) {
-      return (
+      ) : (
         <span className="px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs flex items-center gap-1">
-          <FaTimesCircle /> Lost
-        </span>
-      );
-    } else if (new Date(auction.endTime) < new Date()) {
-      return (
-        <span className="px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs flex items-center gap-1">
-          <FaClock /> Expired
-        </span>
-      );
-    } else {
-      return (
-        <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs flex items-center gap-1">
-          <FaClock /> Active
+          <FaTimesCircle /> Loss
         </span>
       );
     }
+
+    return (
+      <span className="flex items-center gap-1">
+        {auctionLabel}
+        {resultLabel && (
+          <>
+            <span className="text-gray-400">·</span>
+            {resultLabel}
+          </>
+        )}
+      </span>
+    );
   };
 
   const formatDate = (dateString) => {
@@ -129,8 +146,8 @@ const BidHistory = () => {
       return { total: 0, won: 0, lost: 0, active: 0, winRate: 0, totalBidAmount: 0, avgBidAmount: 0 };
 
     // Consider only completed auctions for win/loss statistics
-    const completedBids = bidData.filter(
-      (bid) => bid.auction?.status === "completed"
+    const completedBids = bidData.filter((bid) =>
+      ["completed", "over"].includes(bid.auction?.status)
     );
 
     const total = completedBids.length;
@@ -142,7 +159,7 @@ const BidHistory = () => {
     const active = bidData.filter(
       (bid) =>
         new Date(bid.auction?.endTime) > new Date() &&
-        bid.auction?.status !== "completed"
+        !["completed", "over"].includes(bid.auction?.status)
     ).length;
 
     const totalBidAmount = completedBids.reduce(
@@ -304,7 +321,7 @@ const BidHistory = () => {
                   </div>
                 </div>
                 
-                {bid.auction?.winner && bid.auction?.status === "completed" && isWinningBid(bid) && (
+                {bid.auction?.winner && ["completed", "over"].includes(bid.auction?.status) && isWinningBid(bid) && (
                   <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-lg">
                     <h4 className="font-semibold text-green-800 mb-2">🎉 Congratulations! You Won!</h4>
                     <p className="text-sm text-green-600">
@@ -313,7 +330,7 @@ const BidHistory = () => {
                   </div>
                 )}
 
-                {bid.auction?.winner && !isWinningBid(bid) && bid.auction.status === "completed" && (
+                {bid.auction?.winner && !isWinningBid(bid) && ["completed", "over"].includes(bid.auction.status) && (
                   <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
                     <h4 className="font-semibold text-red-800 mb-2">Better luck next time!</h4>
                     <p className="text-sm text-red-600">

--- a/frontend/src/components/MyBids.jsx
+++ b/frontend/src/components/MyBids.jsx
@@ -37,34 +37,46 @@ const MyBids = () => {
   };
 
 
-    const getBidStatus = (bid, auction) => {
-      const winnerId = getWinnerId(auction);
-      if (auction.status === "completed" && winnerId && winnerId === bid._id?.toString()) {
-        return (
-          <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs flex items-center gap-1">
-            <FaTrophy /> Won
-          </span>
-        );
-      } else if (auction.status === "completed" && winnerId && winnerId !== bid._id?.toString()) {
-        return (
-          <span className="px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs flex items-center gap-1">
-            <FaTimesCircle /> Lost
-          </span>
-        );
-      } else if (new Date(auction.endTime) < new Date()) {
-        return (
-          <span className="px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs flex items-center gap-1">
-            <FaClock /> Expired
-          </span>
-        );
-      } else {
-        return (
-          <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs flex items-center gap-1">
-            <FaClock /> Active
-          </span>
-        );
-      }
-    };
+  const getBidStatus = (bid, auction) => {
+    const winnerId = getWinnerId(auction);
+    const isExpired = ["over", "completed"].includes(auction.status);
+    const isWinner = winnerId && winnerId === bid._id?.toString();
+
+    const auctionLabel = isExpired ? (
+      <span className="px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs flex items-center gap-1">
+        <FaClock /> Expired
+      </span>
+    ) : (
+      <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs flex items-center gap-1">
+        <FaClock /> Active
+      </span>
+    );
+
+    let resultLabel = null;
+    if (isExpired && auction.winner) {
+      resultLabel = isWinner ? (
+        <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs flex items-center gap-1">
+          <FaTrophy /> Win
+        </span>
+      ) : (
+        <span className="px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs flex items-center gap-1">
+          <FaTimesCircle /> Loss
+        </span>
+      );
+    }
+
+    return (
+      <span className="flex items-center gap-1">
+        {auctionLabel}
+        {resultLabel && (
+          <>
+            <span className="text-gray-400">·</span>
+            {resultLabel}
+          </>
+        )}
+      </span>
+    );
+  };
 
 
   const formatDate = (dateString) => {
@@ -84,19 +96,19 @@ const MyBids = () => {
     const total = bidData.length;
     const won = bidData.filter(
       (bid) =>
-        bid.auction?.status === "completed" &&
+        ["completed", "over"].includes(bid.auction?.status) &&
         getWinnerId(bid.auction) === bid._id?.toString()
     ).length;
     const lost = bidData.filter(
       (bid) =>
-        bid.auction?.status === "completed" &&
+        ["completed", "over"].includes(bid.auction?.status) &&
         bid.auction?.winner &&
         getWinnerId(bid.auction) !== bid._id?.toString()
     ).length;
     const active = bidData.filter(
       (bid) =>
         new Date(bid.auction?.endTime) > new Date() &&
-        bid.auction?.status !== "completed"
+        !["completed", "over"].includes(bid.auction?.status)
     ).length;
 
     return { total, won, lost, active };
@@ -216,7 +228,7 @@ const MyBids = () => {
                     </div>
                   </div>
 
-                    {bid.auction?.winner && bid.auction?.status === "completed" && winnerId === bid._id?.toString() && (
+                    {bid.auction?.winner && ["completed", "over"].includes(bid.auction?.status) && winnerId === bid._id?.toString() && (
                       <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-lg">
                         <h4 className="font-semibold text-green-800 mb-2">🎉 Congratulations! You Won!</h4>
                         <p className="text-sm text-green-600">
@@ -225,7 +237,7 @@ const MyBids = () => {
                       </div>
                     )}
 
-                  {bid.auction?.winner && winnerId !== bid._id?.toString() && bid.auction.status === "completed" && (
+                  {bid.auction?.winner && winnerId !== bid._id?.toString() && ["completed", "over"].includes(bid.auction.status) && (
                     <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
                       <h4 className="font-semibold text-red-800 mb-2">Better luck next time!</h4>
                       <p className="text-sm text-red-600">


### PR DESCRIPTION
## Summary
- display auction status and user result together in bid history and my bids
- handle "over" auctions as expired and compare IDs as strings for winner detection
- update filters and stats to use new status logic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 103 errors, 39 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68934e8a5c90832bac148fa5b25484e5