### PR TITLE
Fix fetching of user auctions on profile page

### DIFF
--- a/frontend/src/store/auction/auctionService.js
+++ b/frontend/src/store/auction/auctionService.js
@@ -111,6 +111,20 @@ const getSellerAuction = async () => {
   }
 };
 
+const getAuctionsByUser = async () => {
+  try {
+    const response = await axios.get(
+      `${API_URL}/auctions/user-auctions`,
+      getAuthConfig()
+    );
+    return response.data;
+  } catch (error) {
+    const message =
+      (error.response && error.response.data.message) || error.message;
+    return { message, isError: true };
+  }
+};
+
 const deleteSingleAuctionById = async (id) => {
   try {
     const response = await axios.delete(`${API_URL}/auctions/delete/${id}`, {
@@ -215,6 +229,7 @@ const auctionService = {
   updateAuctionStatus,
   selectAuctionWinner,
   getSellerAuction,
+  getAuctionsByUser,
   deleteSingleAuctionById,
   updateSingleAuction,
   getLiveAuctions,

--- a/frontend/src/store/auction/auctionSlice.js
+++ b/frontend/src/store/auction/auctionSlice.js
@@ -84,13 +84,17 @@ export const getSellerAuction = createAsyncThunk(
 
 export const getAuctionsByUser = createAsyncThunk(
   "auction/getAuctionsByUser",
-  async (userId, thunkAPI) => {
+  async (_, thunkAPI) => {
     try {
-      return await auctionService.getSellerAuction();
+      const response = await auctionService.getAuctionsByUser();
+      if (response?.isError) {
+        return thunkAPI.rejectWithValue({ message: response.message });
+      }
+      return response;
     } catch (error) {
       const message =
         (error.response && error.response.data.message) || error.message;
-      return thunkAPI.rejectWithValue({ message, isError: true });
+      return thunkAPI.rejectWithValue({ message });
     }
   }
 );


### PR DESCRIPTION
## Summary
- Add authorized `getAuctionsByUser` service to retrieve logged-in user's auctions
- Update auction slice thunk to use new service and propagate errors

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` *(fails: multiple lint errors)*
- `npm test` (backend) *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a99ce2c478832b89138b912d4ccf82